### PR TITLE
セーブデータ関連の改修

### DIFF
--- a/Assets/Scenes/title/TitleScene.unity
+++ b/Assets/Scenes/title/TitleScene.unity
@@ -398,6 +398,50 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+--- !u!1 &451708214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 451708216}
+  - component: {fileID: 451708215}
+  m_Layer: 0
+  m_Name: Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &451708215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451708214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 933eacb15bd1426488a9421439d1c1bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &451708216
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451708214}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0121205915, y: 0.30776212, z: -1.3640555}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -1069,3 +1113,4 @@ SceneRoots:
   - {fileID: 1192477082}
   - {fileID: 707532582}
   - {fileID: 754957813}
+  - {fileID: 451708216}

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
 using Newtonsoft.Json;
+using UnityEngine.SceneManagement;
 
 public class Manager : MonoBehaviour
 {
     public static Manager instance; //シングルトン用インスタンス
 
     public static List<Savedata> savedata = new List<Savedata>(); //セーブデータのリスト
+    public static Savedata newData = new Savedata();              //最新のセーブデータ格納用
     public static List<Quiz> quiz = new List<Quiz>(); //クイズのリスト
     public static int currentQuiz = 0; //現在のクイズのインデックス
     public static float interval = 0.33f;   //ノーツ生成の間隔
@@ -16,18 +18,20 @@ public class Manager : MonoBehaviour
     [System.Serializable]
     public class Savedata
     {
-        public string gotStatement;     //�����������蕶
-        public int canceledNoise = 0;   //�L�����Z�������m�C�Y�̌�
-        public int generatedNoise = 0;  //���������m�C�Y�̌�
-        public int selectedAnswer;      //�I�΂ꂽ�I����
+        public string gotStatement = "";     //聞き取った問題文(聞き取れなかったところは空白)
+        public int gotVoice = 0;            //聞き取れた文字数
+        public int canceledNoise = 0;   //キャンセルしたノイズの個数
+        public int generatedNoise = 0;  //発生したノイズの個数
+        public int selectedAnswer;      //選ばれた選択肢
+        public bool isCorrect;          //回答が正しかったか(正しかったらtrue)
     }
 
     [System.Serializable]
     public class Quiz
     {
-        public string statement;       //��蕶
-        public List<string> choices;   //�I�����̕���
-        public int answer;             //�ǂ̑I������������
+        public string statement;       //問題文
+        public List<string> choices;   //選択肢の文章
+        public int answer;             //どの選択肢が正解か
     }
 
     void Awake()
@@ -37,13 +41,17 @@ public class Manager : MonoBehaviour
             instance = this;
             DontDestroyOnLoad(gameObject);
             //完成するまでのデバッグ用セーブデータ
-            Savedata data = new();
-            data.gotStatement = "聖  子が  れたのは 歴何年？";
-            data.canceledNoise = 3;
-            data.generatedNoise = 3;
-            data.selectedAnswer = 2;
-            Save(data);
-            GenerateQuiz();
+            if (SceneManager.GetActiveScene().name != "TitleScene")
+            {
+                newData.gotStatement = "聖  子が  れたのは 歴何年？";
+                newData.gotVoice = 11;
+                newData.canceledNoise = 3;
+                newData.generatedNoise = 3;
+                newData.selectedAnswer = 2;
+                newData.isCorrect = true;
+                Save();
+                GenerateQuiz();
+            }
         }
         else
         {
@@ -58,8 +66,9 @@ public class Manager : MonoBehaviour
         Debug.Log(quiz);
     }
 
-    public static void Save(Savedata data)
+    public static void Save()
     {
-        savedata.Add(data); //セーブデータをリストに追加
+        savedata.Add(newData); //セーブデータをリストに追加
+        newData = new();
     }
 }


### PR DESCRIPTION
TitleSceneにもManagerを追加
TitleScene以外でManagerのAwakeが呼び出されたら仮データを作成するように
Savedataが聞き取れた文字数とクイズの正誤も保持するようにし、データが揃うまでの一時セーブデータとして新たな変数newDataを用意、Save関数によりセーブを確定させnewDataをクリアするようにした